### PR TITLE
WIP: Scrolling board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 *.log
 *.swp
+.vscode/

--- a/cursello.py
+++ b/cursello.py
@@ -135,11 +135,18 @@ def main(stdscr):
   if data is None or len(data) == 0:
     data = [List("To Do"), List("Done")]
 
+  yx = stdscr.getmaxyx()
+  pad = curses.newpad(yx[0], yx[1])
+  pad.refresh(0,0,0,0,yx[0]-1, yx[1]-1)
+  pad_pos_x = 0
+  pad_pos_y = 0
+
   ilist = 0
   item = 0
   while True:
-    refresh_lists(stdscr, data, ilist, item)
+    refresh_lists(pad, data, ilist, item)
     stdscr.refresh()
+    pad.refresh(pad_pos_y,pad_pos_x,0,0,yx[0]-1, yx[1]-1)
     c = stdscr.getch()
     # Move down within list
     if c == ord('j'):
@@ -157,27 +164,35 @@ def main(stdscr):
       item = min(item, data[ilist].size - 1)
     # Create new item in list
     elif c == ord('o'):
-      new_item(stdscr, data, ilist)
+      new_item(pad, data, ilist)
     # Create new list
     elif c == ord('a'):
-      new_list(stdscr, data, ilist)
+      new_list(pad, data, ilist)
     # Delete Item
     elif c == ord('d'):
-      delete_item(stdscr, data, ilist, item)
+      delete_item(pad, data, ilist, item)
     # Delete List
     elif c == ord('D'):
-      delete_list(stdscr, data, ilist)
+      delete_list(pad, data, ilist)
     # Save board
     elif c == ord('w'):
-      save_board(stdscr, data)
+      save_board(pad, data)
     # Switch boards
     elif c == ord('m'):
-      data = switch_board(stdscr, data)
+      data = switch_board(pad, data)
       ilist = 0
       item = 0
     # Quit
     elif c == ord('q'):
       break
+    elif c == curses.KEY_RIGHT and pad_pos_x < yx[1] - 1:
+      pad_pos_x += 1
+    elif c == curses.KEY_LEFT and pad_pos_x > 0:
+      pad_pos_x -= 1
+    elif c == curses.KEY_UP and pad_pos_y > 0:
+      pad_pos_y -= 1
+    elif c == curses.KEY_DOWN and pad_pos_y < yx[0] - 1:
+      pad_pos_y += 1
     else:
       pass
 

--- a/cursello.py
+++ b/cursello.py
@@ -10,192 +10,205 @@ from modules.list import List
 from modules.cursello_io import BarInput
 from modules.cursello_io import debug
 
-stdscr = curses.initscr()
-curses.noecho()
-curses.start_color()
-curses.curs_set(0)
-stdscr.refresh()
 
-changes_made = False
+class Cursello:
 
-if len(sys.argv) == 2:
-  # User has given board name
-  board_name = sys.argv[1]
-  if '.yaml' not in board_name:
-    board_name += '.yaml'
+  def __init__(self):
+    self.win = curses.initscr()
 
-  storage.STORAGE_FILE = board_name
+    yx = self.win.getmaxyx()
+    self.stdscr = curses.newpad(1000, 1000)
+    self.stdscr.keypad(1)
 
-def refresh_lists(stdscr, data, ilist, itemw):
-  stdscr.clear()
-  at = 1
-  for i, items in enumerate(data):
-    width = max(map(len, items.items) + [len(items.name)]) + 1
-    #rectangle(stdscr, 0, at - 1, items.size + 2, at + width)
-    rectangle(stdscr, 0, at - 1, items.size + 2, at + width)
+    curses.noecho()
+    curses.start_color()
+    curses.curs_set(0)
+    self.stdscr.refresh(0,0,0,0,yx[0]-1, yx[1]-1)
 
-    text_type = 0
-    if i == ilist: text_type = curses.A_UNDERLINE
-    stdscr.addstr(1, at, items.name, text_type)
+    self.pad_pos_x = 0
+    self.pad_pos_y = 0
+    self.data = {}
+    self.ilist = 0
+    self.item = 0
 
-    for j, item in enumerate(items.items):
+    self.changes_made = False
+
+    if len(sys.argv) == 2:
+      # User has given board name
+      board_name = sys.argv[1]
+      if '.yaml' not in board_name:
+        board_name += '.yaml'
+
+      storage.STORAGE_FILE = board_name
+
+  def refresh_lists(self):
+    self.stdscr.clear()
+    at = 1
+    for i, items in enumerate(self.data):
+      width = max(map(len, items.items) + [len(items.name)]) + 1
+      #rectangle(stdscr, 0, at - 1, items.size + 2, at + width)
+      rectangle(self.stdscr, 0, at - 1, items.size + 2, at + width)
+
       text_type = 0
-      if j == itemw and i == ilist: text_type = curses.A_BOLD
-      #stdscr.addstr(j + 2, at, item, text_type)
-      stdscr.addstr(j + 2, at, item, text_type)
-    at += width + 2
+      if i == self.ilist: text_type = curses.A_UNDERLINE
+      self.stdscr.addstr(1, at, items.name, text_type)
+
+      for j, itemw in enumerate(items.items):
+        text_type = 0
+        if j == self.item and i == self.ilist: text_type = curses.A_BOLD
+        #stdscr.addstr(j + 2, at, item, text_type)
+        self.stdscr.addstr(j + 2, at, itemw, text_type)
+      at += width + 2
 
 
-def new_item(stdscr, data, ilist):
-  global changes_made
-  changes_made = True
-  item_string = BarInput(stdscr, "Enter the item description, then press enter: ")
-  data[ilist].add(item_string)
+  def new_item(self):
+    self.changes_made = True
+    item_string = BarInput(self, "Enter the item description, then press enter: ")
+    self.data[self.ilist].add(item_string)
 
 
-def new_list(stdscr, data, ilist):
-  global changes_made
-  changes_made = True
-  item_string = BarInput(stdscr, "Enter the name of the new list, then press enter: ")
-  data.append(List(item_string))
-  ilist = len(data) - 1
+  def new_list(self):
+    self.changes_made = True
+    item_string = BarInput(self, "Enter the name of the new list, then press enter: ")
+    self.data.append(List(item_string))
+    self.ilist = len(self.data) - 1
 
 
-def delete_item(stdscr, data, ilist, item):
-  global changes_made
-  changes_made = True
-  if ilist >= len(data) or ilist < 0 or item >= data[ilist].size or item < 0:
-    return
-  answer = BarInput(stdscr, "Are you sure you wish to delete this item? (y/n): ")
-  if answer == 'y':
-    data[ilist].archive(item)
+  def delete_item(self):
+    self.changes_made = True
+    if self.ilist >= len(self.data) or self.ilist < 0 or self.item >= self.data[self.ilist].size or self.item < 0:
+      return
+    answer = BarInput(self, "Are you sure you wish to delete this item? (y/n): ")
+    if answer == 'y':
+      self.data[self.ilist].archive(self.item)
+
+    self.item = min(self.item, self.data[self.ilist].size - 1)
 
 
-def delete_list(stdscr, data, ilist):
-  global changes_made
-  changes_made = True
-  if ilist >= len(data) or ilist < 0:
-    return
-  answer = BarInput(stdscr, "Are you sure you wish to delete this entire list? (y/n): ")
-  if answer == 'y':
-    del data[ilist]
+  def delete_list(self):
+    self.changes_made = True
+    if self.ilist >= len(self.data) or self.ilist < 0:
+      return
+    answer = BarInput(self, "Are you sure you wish to delete this entire list? (y/n): ")
+    if answer == 'y':
+      del self.data[self.ilist]
+
+    self.ilist = min(self.ilist, len(self.data) - 1)
+    self.item = min(self.item, self.data[self.ilist].size - 1)
 
 
-def save_board(stdscr, data):
-  global changes_made
-  board_name = BarInput(stdscr, 'What name do you want to save this board as? Leave blank to save as "' + storage.STORAGE_FILE.strip('.yaml') + '": ')
+  def save_board(self):
+    board_name = BarInput(self, 'What name do you want to save this board as? Leave blank to save as "' + storage.STORAGE_FILE.strip('.yaml') + '": ')
 
-  if not board_name == '':
+    if not board_name == '':
+      if '.yaml' not in board_name:
+        board_name += '.yaml'
+
+      storage.STORAGE_FILE = board_name
+
+    storage.write_store(self.data)
+
+    self.changes_made = False
+
+
+  def switch_board(self):
+
+    if self.changes_made:
+      # User has unsaved changes, prompt to see if they wish to save
+      answer = BarInput(self, 'You have unsaved changes in the current board, do you wish to save them? (y/n): ')
+      if answer == 'y':
+        save_board(self.stdscr, self.data)
+
+    self.changes_made = False
+
+    board_name = BarInput(self.stdscr, 'Which board do you wish to switch to: ')
+
     if '.yaml' not in board_name:
       board_name += '.yaml'
 
     storage.STORAGE_FILE = board_name
 
-  storage.write_store(data)
+    storage_file_present = storage.check_store()
+    self.data = storage.load_store()
+    if self.data is None or len(self.data) == 0:
+      self.data = [List("To Do"), List("Done")]
 
-  changes_made = False
-
-
-def switch_board(stdscr, data):
-  global changes_made
-
-  if changes_made:
-    # User has unsaved changes, prompt to see if they wish to save
-    answer = BarInput(stdscr, 'You have unsaved changes in the current board, do you wish to save them? (y/n): ')
-    if answer == 'y':
-      save_board(stdscr, data)
-
-  changes_made = False
-
-  board_name = BarInput(stdscr, 'Which board do you wish to switch to: ')
-
-  if '.yaml' not in board_name:
-    board_name += '.yaml'
-
-  storage.STORAGE_FILE = board_name
-
-  storage_file_present = storage.check_store()
-  data = storage.load_store()
-  if data is None or len(data) == 0:
-    data = [List("To Do"), List("Done")]
-
-  return data
+    return self.data
 
 
-def init(stdscr):
-  stdscr.addstr(curses.LINES - 1, 0, "(q) to quit. (o) to add an item to a list. Vim style movement.", curses.A_BOLD)
+  def init(self):
+    self.stdscr.addstr(curses.LINES - 1, 0, "(q) to quit. (o) to add an item to a list. Vim style movement.", curses.A_BOLD)
 
-def handle_shutdown(data):
-  storage.write_store(data)
+  def handle_shutdown(self):
+    storage.write_store(self.data)
 
-def main(stdscr):
-  # Load/prepare storage.
-  storage_file_present = storage.check_store()
-  data = storage.load_store()
-  if data is None or len(data) == 0:
-    data = [List("To Do"), List("Done")]
+  def main(self, screen):
+    # Load/prepare storage.
+    storage_file_present = storage.check_store()
+    self.data = storage.load_store()
+    if self.data is None or len(self.data) == 0:
+      self.data = [List("To Do"), List("Done")]
 
-  yx = stdscr.getmaxyx()
-  pad = curses.newpad(yx[0], yx[1])
-  pad.refresh(0,0,0,0,yx[0]-1, yx[1]-1)
-  pad_pos_x = 0
-  pad_pos_y = 0
+    yx = self.win.getmaxyx()
+    self.stdscr.refresh(0,0,0,0,yx[0]-1, yx[1]-1)
 
-  ilist = 0
-  item = 0
-  while True:
-    refresh_lists(pad, data, ilist, item)
-    stdscr.refresh()
-    pad.refresh(pad_pos_y,pad_pos_x,0,0,yx[0]-1, yx[1]-1)
-    c = stdscr.getch()
-    # Move down within list
-    if c == ord('j'):
-      item = min(item + 1, data[ilist].size - 1)
-    # Move up within list
-    elif c == ord('k'):
-      item = max(item - 1, 0)
-    # Move right to next list
-    elif c == ord('l'):
-      ilist = min(ilist + 1, len(data) - 1)
-      item = min(item, data[ilist].size - 1)
-    # Move left to next list
-    elif c == ord('h'):
-      ilist = max(ilist - 1, 0)
-      item = min(item, data[ilist].size - 1)
-    # Create new item in list
-    elif c == ord('o'):
-      new_item(pad, data, ilist)
-    # Create new list
-    elif c == ord('a'):
-      new_list(pad, data, ilist)
-    # Delete Item
-    elif c == ord('d'):
-      delete_item(pad, data, ilist, item)
-    # Delete List
-    elif c == ord('D'):
-      delete_list(pad, data, ilist)
-    # Save board
-    elif c == ord('w'):
-      save_board(pad, data)
-    # Switch boards
-    elif c == ord('m'):
-      data = switch_board(pad, data)
-      ilist = 0
-      item = 0
-    # Quit
-    elif c == ord('q'):
-      break
-    elif c == curses.KEY_RIGHT and pad_pos_x < yx[1] - 1:
-      pad_pos_x += 1
-    elif c == curses.KEY_LEFT and pad_pos_x > 0:
-      pad_pos_x -= 1
-    elif c == curses.KEY_UP and pad_pos_y > 0:
-      pad_pos_y -= 1
-    elif c == curses.KEY_DOWN and pad_pos_y < yx[0] - 1:
-      pad_pos_y += 1
-    else:
-      pass
+    while True:
+      self.refresh_lists()
+      self.stdscr.refresh(self.pad_pos_y,self.pad_pos_x,0,0,yx[0]-1, yx[1]-1)
+      c = self.stdscr.getch()
+      l = open('log', 'w+')
+      l.write(str(c))
+      l.flush()
+      l.close()
+      # Move down within list
+      if c == ord('j'):
+        self.item = min(self.item + 1, self.data[self.ilist].size - 1)
+      # Move up within list
+      elif c == ord('k'):
+        self.item = max(self.item - 1, 0)
+      # Move right to next list
+      elif c == ord('l'):
+        self.ilist = min(self.ilist + 1, len(self.data) - 1)
+        self.item = min(self.item, self.data[self.ilist].size - 1)
+      # Move left to next list
+      elif c == ord('h'):
+        self.ilist = max(self.ilist - 1, 0)
+        self.item = min(self.item, self.data[self.ilist].size - 1)
+      # Create new item in list
+      elif c == ord('o'):
+        self.new_item()
+      # Create new list
+      elif c == ord('a'):
+        self.new_list()
+      # Delete Item
+      elif c == ord('d'):
+        self.delete_item()
+      # Delete List
+      elif c == ord('D'):
+        self.delete_list()
+      # Save board
+      elif c == ord('w'):
+        self.save_board()
+      # Switch boards
+      elif c == ord('m'):
+        self.data = self.switch_board()
+        self.ilist = 0
+        self.item = 0
+      # Quit
+      elif c == ord('q'):
+        break
+      elif c == curses.KEY_RIGHT and self.pad_pos_x < yx[1] - 1:
+        self.pad_pos_x += 1
+      elif c == curses.KEY_LEFT and self.pad_pos_x > 0:
+        self.pad_pos_x -= 1
+      elif c == curses.KEY_UP and self.pad_pos_y > 0:
+        self.pad_pos_y -= 1
+      elif c == curses.KEY_DOWN and self.pad_pos_y < yx[0] - 1:
+        self.pad_pos_y += 1
+      else:
+        pass
 
-  handle_shutdown(data)
+    self.handle_shutdown()
 
-curses.wrapper(main)
+cursello = Cursello()
+curses.wrapper(cursello.main)

--- a/modules/cursello_io.py
+++ b/modules/cursello_io.py
@@ -44,7 +44,7 @@ def BarInput(screen, prompt):
 
   # Display the prompt message
   screen.addstr(screen_xy[0] - 1, 0, prompt, curses.A_BOLD)
-  screen.refresh()
+  screen.refresh(0,0, 0,0, screen.getmaxyx()[0]-1, screen.getmaxyx()[1]-1)
 
   # Get user input after the prompt message
   st = screen.getstr(screen_xy[0] - 1, len(prompt))

--- a/modules/cursello_io.py
+++ b/modules/cursello_io.py
@@ -41,21 +41,20 @@ def BarInput(cursello, prompt):
   #Reactivate the cursor
   curses.curs_set(1)
   curses.echo()
-  screen.immedok(1)
 
   # Display the prompt message
-  screen.addstr(screen_yx[0] - 1, 0, prompt, curses.A_BOLD)
+  screen.addstr(screen_yx[0] - 1, 0, prompt)
   # screen.refresh(cursello.pad_pos_y,cursello.pad_pos_x, 0,0, screen_yx[0]-1, screen_yx[1]-1)
   screen.refresh()
+
   # Get user input after the prompt message
   st = screen.getstr(screen_yx[0] - 1, len(prompt))
 
   # reset things
   curses.curs_set(0)
   curses.noecho()
-  screen.immedok(0)
-  screen.addstr(screen_yx[0] - 1, 0, ' ' * (screen_yx[1]-1))
   screen.clear()
   screen.refresh()
+
   # return string
   return st.strip()

--- a/modules/cursello_io.py
+++ b/modules/cursello_io.py
@@ -7,7 +7,6 @@ Douglas J. Smith
 12/28/17
 '''
 import curses
-
 '''
 debug - take a string and a screen and display the string at the base of the
   window, useful for alerts or certain I/O display.
@@ -34,25 +33,29 @@ prompt:String - string that is used to request input. Prompt is flashed before
 OUTPUT:
 result:String - processed version of user's input
 '''
-def BarInput(screen, prompt):
+def BarInput(cursello, prompt):
+  screen = cursello.win
 
-  screen_xy = screen.getmaxyx()
+  screen_yx = screen.getmaxyx()
 
   #Reactivate the cursor
   curses.curs_set(1)
   curses.echo()
+  screen.immedok(1)
 
   # Display the prompt message
-  screen.addstr(screen_xy[0] - 1, 0, prompt, curses.A_BOLD)
-  screen.refresh(0,0, 0,0, screen.getmaxyx()[0]-1, screen.getmaxyx()[1]-1)
-
+  screen.addstr(screen_yx[0] - 1, 0, prompt, curses.A_BOLD)
+  # screen.refresh(cursello.pad_pos_y,cursello.pad_pos_x, 0,0, screen_yx[0]-1, screen_yx[1]-1)
+  screen.refresh()
   # Get user input after the prompt message
-  st = screen.getstr(screen_xy[0] - 1, len(prompt))
+  st = screen.getstr(screen_yx[0] - 1, len(prompt))
 
   # reset things
   curses.curs_set(0)
   curses.noecho()
-  screen.addstr(screen_xy[0] - 1, 0, ' ' * (screen_xy[1]-1))
-
+  screen.immedok(0)
+  screen.addstr(screen_yx[0] - 1, 0, ' ' * (screen_yx[1]-1))
+  screen.clear()
+  screen.refresh()
   # return string
   return st.strip()


### PR DESCRIPTION
So I've been toying around with this idea of how to make the board scrollable so that terminal size is not a limiting factor. It uses a pad that is an arbitrary size, and then only displays the portion of the pad that fits in the window. The user can scroll around using arrow keys. It all works great apart from the input. A [pad](https://docs.python.org/2/library/curses.html#curses.newpad) does not auto refresh, meaning that if I were to implement the input also on the pad, I could get a prompt that is independent of screen size, but the user input is no longer seen. 

Currently, in this branch I have it set so that it uses the original window, as that allows for auto refresh, but it keeps the original issue that if a prompt is longer than the screen width, it will crash cursello. I see two main ways of solving this:
- Have a detection on the length of the prompt, and split it up so that it will fit on multiple lines in the terminal. ie if the prompt is 100 chars long, and terminal is only 70 wide, split the prompt into 2 lines. In edge cases where the terminal is only 1 line tall this would obviously not work. We would also need to account for how much space the user input should have, so final length is length of prompt + length of max user input.
- Use a sort of hybrid of the previous io method, where you would manually listen for user input and print them to the pad manually. This would be the most flexible on, but I feel is poor design.

My vote is on the first method, as I think keeping the prompt neatly on the screen is important, as the user may not realise they need to scroll to view prompt, and also scrolling to read the entire prompt is a bit of a pain. There is obviously the extreme edge case i mentioned, but I think in general it is the best way to go about it. Thoughts?

Relevant issues #4  #16  